### PR TITLE
Adding docs directory

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,35 @@
+For any problems with this charm, please [report bugs here](https://bugs.launchpad.net/charm-k8s-content-cache).
+
+The code for this charm can be downloaded as follows:
+
+```
+git clone https://git.launchpad.net/charm-k8s-content-cache
+```
+
+To run tests, simply run  `make test`  from within the charm code directory.
+
+## Using a Custom Image
+
+Build the docker image:
+
+    git clone https://git.launchpad.net/charm-k8s-content-cache
+    cd charm-k8s-content-cache/docker
+    docker build . -t myimage:v<revision>
+    docker tag myimage:v<revision> localhost:32000/myimage:v<revision>
+    docker push localhost:32000/myimage:v<revision>
+
+Then, to use your new image, either replace the `deploy` step above with
+
+    juju deploy cs:~content-cache-charmers/content-cache-k8s --config image_path=localhost:32000/myimage:v<revision> --config site=mysite.local --config backend=http://mybackend.local:80                                                                                                
+
+Or, if you have already deployed content-cache:
+
+    juju config content-cache image_path=localhost:32000/myimage:v<revision>
+
+## Developing
+
+To build the charm locally, just run `charmcraft build`. You can then deploy using:
+
+    juju deploy ./content-cache.charm
+
+To run lint against the code, run `make lint`.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,1 @@
+This service is based on [Nginx](https://nginx.com) and can be used either as a front-end caching service providing high bandwidth access to sites (as a kind of CDN), or as a local cache of sites.


### PR DESCRIPTION
Adding the currently existing docs to the docs folder, in order to use the publish docs action from https://github.com/canonical/upload-charm-docs