### PR TITLE
Update integration tests to use any-charm instead of hello-kubecon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 [tool.bandit]
-exclude_dirs = ["/venv/"]
+exclude_dirs = ["/venv/", "tests/integration/any_charm.py"]
 [tool.bandit.assert_used]
 skips = ["*/*test.py", "*/test_*.py"]
 
@@ -48,3 +48,7 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.pyright]
+venvPath = "."
+venv = "venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,3 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
-
-[tool.pyright]
-venvPath = "."
-venv = "venv"

--- a/src/charm.py
+++ b/src/charm.py
@@ -216,7 +216,7 @@ class ContentCacheCharm(CharmBase):
         hashed_name = hashed_value.hexdigest()[0:12]
         return f"{hashed_name}-cache"
 
-    def _make_ingress_config(self) -> list:
+    def _make_ingress_config(self) -> dict:
         """Return an assembled K8s ingress."""
         config = self.model.config
 

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import signal
 import subprocess
+import tempfile
 
 from any_charm_base import AnyCharmBase
 from ingress import IngressRequires
@@ -27,10 +28,7 @@ class AnyCharm(AnyCharmBase):
     @staticmethod
     def start_server(port: int = 80):
         """Start an HTTP server daemon."""
-        www_dir = pathlib.Path("/tmp/www")
-        www_dir.mkdir(exist_ok=True)
-        ok_file = www_dir / "ok"
-        ok_file.write_text("ok")
+        www_dir = tempfile.mkdtemp()
         # We create a pid file to avoid concurrent executions of the http server
         pid_file = pathlib.Path("/tmp/any.pid")
         if pid_file.exists():

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -12,6 +12,8 @@ from ingress import IngressRequires
 
 
 class AnyCharm(AnyCharmBase):
+    """Execute a simple web-server charm to test the ingress-proxy relation"""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ingress = IngressRequires(

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -31,6 +31,7 @@ class AnyCharm(AnyCharmBase):
         www_dir.mkdir(exist_ok=True)
         ok_file = www_dir / "ok"
         ok_file.write_text("ok")
+        # We create a pid file to avoid concurrent executions of the http server
         pid_file = pathlib.Path("/tmp/any.pid")
         if pid_file.exists():
             os.kill(int(pid_file.read_text()), signal.SIGKILL)

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This code snippet is used to be loaded into any-charm which is used for integration tests."""
+import os
+import pathlib
+import signal
+import subprocess
+
+from any_charm_base import AnyCharmBase
+from ingress import IngressRequires
+
+
+class AnyCharm(AnyCharmBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ingress = IngressRequires(
+            self,
+            {"service-hostname": self.app.name, "service-name": self.app.name, "service-port": 80},
+        )
+
+    def update_ingress(self, ingress_config):
+        self.ingress.update_config(ingress_config)
+
+    @staticmethod
+    def start_server(port: int = 80):
+        """Start an HTTP server daemon."""
+        www_dir = pathlib.Path("/tmp/www")
+        www_dir.mkdir(exist_ok=True)
+        ok_file = www_dir / "ok"
+        ok_file.write_text("ok")
+        pid_file = pathlib.Path("/tmp/any.pid")
+        if pid_file.exists():
+            os.kill(int(pid_file.read_text()), signal.SIGKILL)
+            pid_file.unlink()
+        p = subprocess.Popen(
+            ["python3", "-m", "http.server", "-d", www_dir, str(port)],
+            start_new_session=True,
+        )
+        pid_file.write_text(str(p.pid))
+        return port

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import configparser
 import json
 import re
 from pathlib import Path
-from typing import List
+from typing import Any, Awaitable, Callable, List
 
 import pytest_asyncio
 import yaml
@@ -28,10 +28,10 @@ def app_name(metadata):
 
 
 @fixture(scope="module")
-def run_action(ops_test: OpsTest):
+def run_action(ops_test: OpsTest) -> Callable[[str, str], Awaitable[Any]]:
     """Create a async function to run action and return results."""
 
-    async def _run_action(application_name, action_name, **params):
+    async def _run_action(application_name: str, action_name: str, **params):
         application = ops_test.model.applications[application_name]
         action = await application.units[0].run_action(action_name, **params)
         await action.wait()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@
 # see LICENCE file for details.
 
 import configparser
+import json
 import re
 from pathlib import Path
 from typing import List
@@ -88,12 +89,23 @@ async def app(
 ):
     """Content-cache-k8s charm used for integration testing.
 
-    Deploy kubecon charm, builds the charm and deploys it for testing purposes.
+    Deploy any-charm charm, builds the charm and deploys it for testing purposes.
     """
-    hello_kubecon_app_name = "hello-kubecon"
-    ops_test.model.deploy(hello_kubecon_app_name)
-    await ops_test.model.deploy(hello_kubecon_app_name)
-    await ops_test.model.wait_for_idle()
+
+    any_app_name = "any-app"
+    ingress_lib = Path("lib/charms/nginx_ingress_integrator/v0/ingress.py").read_text()
+    any_charm_script = Path("tests/integration/any_charm.py").read_text()
+    any_charm_src_overwrite = {
+        "ingress.py": ingress_lib,
+        "any_charm.py": any_charm_script,
+    }
+    await ops_test.model.deploy(
+        "any-charm",
+        application_name=any_app_name,
+        channel="beta",
+        config={"src-overwrite": json.dumps(any_charm_src_overwrite)},
+    )
+    await ops_test.model.wait_for_idle(status="active")
 
     app_charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(
@@ -107,18 +119,15 @@ async def app(
         await ops_test.model.wait_for_idle(raise_on_blocked=True)
     except (JujuAppError, JujuUnitError):
         print("BlockedStatus raised: will be solved after relation ingress-proxy")
-        pass
-    apps = [app_name, nginx_integrator_app.name, hello_kubecon_app_name]
-    await ops_test.model.add_relation(hello_kubecon_app_name, f"{app_name}:ingress-proxy")
+
+    apps = [app_name, nginx_integrator_app.name, any_app_name]
+    await ops_test.model.add_relation(any_app_name, f"{app_name}:ingress-proxy")
     await ops_test.model.wait_for_idle(apps=apps, status=ActiveStatus.name, timeout=60 * 5)
-    await ops_test.model.add_relation(f"{app_name}:ingress", nginx_integrator_app.name)
+    await ops_test.model.add_relation(nginx_integrator_app.name, f"{app_name}:ingress")
     await ops_test.model.wait_for_idle(apps=apps, status=ActiveStatus.name, timeout=60 * 5)
 
     assert ops_test.model.applications[app_name].units[0].workload_status == ActiveStatus.name
-    assert (
-        ops_test.model.applications[hello_kubecon_app_name].units[0].workload_status
-        == ActiveStatus.name
-    )
+    assert ops_test.model.applications[any_app_name].units[0].workload_status == ActiveStatus.name
 
     yield application
 

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -81,68 +81,68 @@ async def test_report_visits_by_ip(app: Application):
     assert ip_address_list
 
 
-# @pytest.mark.asyncio
-# async def test_openstack_object_storage_plugin(
-#     ops_test: pytest_operator.plugin.OpsTest,
-#     unit_ip_list,
-#     openstack_environment,
-#     app: Application,
-# ):
-#     """
-#     arrange: after charm deployed and openstack swift server ready.
-#     act: update charm configuration for openstack object storage plugin.
-#     assert: a file should be uploaded to the openstack server and be accesibe through it.
-#     """
-#     swift_conn = swiftclient.Connection(
-#         authurl=openstack_environment["OS_AUTH_URL"],
-#         auth_version="3",
-#         user=openstack_environment["OS_USERNAME"],
-#         key=openstack_environment["OS_PASSWORD"],
-#         os_options={
-#             "user_domain_name": openstack_environment["OS_USER_DOMAIN_ID"],
-#             "project_domain_name": openstack_environment["OS_PROJECT_DOMAIN_ID"],
-#             "project_name": openstack_environment["OS_PROJECT_NAME"],
-#         },
-#     )
-#     container_exists = True
-#     container = "content-cache"
-#     try:
-#         swift_conn.head_container(container)
-#     except swiftclient.exceptions.ClientException as e:
-#         if e.http_status == 404:
-#             container_exists = False
-#         else:
-#             raise e
-#     if container_exists:
-#         for swift_object in swift_conn.get_container(container, full_listing=True)[1]:
-#             swift_conn.delete_object(container, swift_object["name"])
-#         swift_conn.delete_container(container)
-#     swift_conn.put_container(container)
-#     app = ops_test.model.applications["content-cache-k8s"]
-#     await app.set_config({"backend": f"http://{swift_conn.url}:80"})
-#     await app.set_config({"site": swift_conn.url})
-#     swift_service = swiftclient.service.SwiftService(
-#         options=dict(
-#             auth_version="3",
-#             os_auth_url=openstack_environment["OS_AUTH_URL"],
-#             os_username=openstack_environment["OS_USERNAME"],
-#             os_password=openstack_environment["OS_PASSWORD"],
-#             os_project_name=openstack_environment["OS_PROJECT_NAME"],
-#             os_project_domain_name=openstack_environment["OS_PROJECT_DOMAIN_ID"],
-#         )
-#     )
-#     swift_service.post(container=container, options={"read_acl": ".r:*,.rlistings"})
-#     for idx, unit_ip in enumerate(unit_ip_list):
-#         nonce = secrets.token_hex(8)
-#         filename = f"{nonce}.{unit_ip}.{idx}"
-#         content = "test-content"
-#         swift_conn.put_object(container=container, obj=filename, contents=content)
-#         swift_object_list = [
-#             o["name"] for o in swift_conn.get_container(container, full_listing=True)[1]
-#         ]
-#         assert any(
-#             filename in f for f in swift_object_list
-#         ), "media file uploaded should be stored in swift object storage"
-#         response = requests.get(f"{swift_conn.url}/{container}/{filename}", timeout=5)
-#         assert response.status_code == 200, "the image should be accessible from the swift server"
-#         assert response.text == content
+@pytest.mark.asyncio
+async def test_openstack_object_storage_plugin(
+    ops_test: pytest_operator.plugin.OpsTest,
+    unit_ip_list,
+    openstack_environment,
+    app: Application,
+):
+    """
+    arrange: after charm deployed and openstack swift server ready.
+    act: update charm configuration for openstack object storage plugin.
+    assert: a file should be uploaded to the openstack server and be accesibe through it.
+    """
+    swift_conn = swiftclient.Connection(
+        authurl=openstack_environment["OS_AUTH_URL"],
+        auth_version="3",
+        user=openstack_environment["OS_USERNAME"],
+        key=openstack_environment["OS_PASSWORD"],
+        os_options={
+            "user_domain_name": openstack_environment["OS_USER_DOMAIN_ID"],
+            "project_domain_name": openstack_environment["OS_PROJECT_DOMAIN_ID"],
+            "project_name": openstack_environment["OS_PROJECT_NAME"],
+        },
+    )
+    container_exists = True
+    container = "content-cache"
+    try:
+        swift_conn.head_container(container)
+    except swiftclient.exceptions.ClientException as e:
+        if e.http_status == 404:
+            container_exists = False
+        else:
+            raise e
+    if container_exists:
+        for swift_object in swift_conn.get_container(container, full_listing=True)[1]:
+            swift_conn.delete_object(container, swift_object["name"])
+        swift_conn.delete_container(container)
+    swift_conn.put_container(container)
+    app = ops_test.model.applications["content-cache-k8s"]
+    await app.set_config({"backend": f"http://{swift_conn.url}:80"})
+    await app.set_config({"site": swift_conn.url})
+    swift_service = swiftclient.service.SwiftService(
+        options=dict(
+            auth_version="3",
+            os_auth_url=openstack_environment["OS_AUTH_URL"],
+            os_username=openstack_environment["OS_USERNAME"],
+            os_password=openstack_environment["OS_PASSWORD"],
+            os_project_name=openstack_environment["OS_PROJECT_NAME"],
+            os_project_domain_name=openstack_environment["OS_PROJECT_DOMAIN_ID"],
+        )
+    )
+    swift_service.post(container=container, options={"read_acl": ".r:*,.rlistings"})
+    for idx, unit_ip in enumerate(unit_ip_list):
+        nonce = secrets.token_hex(8)
+        filename = f"{nonce}.{unit_ip}.{idx}"
+        content = "test-content"
+        swift_conn.put_object(container=container, obj=filename, contents=content)
+        swift_object_list = [
+            o["name"] for o in swift_conn.get_container(container, full_listing=True)[1]
+        ]
+        assert any(
+            filename in f for f in swift_object_list
+        ), "media file uploaded should be stored in swift object storage"
+        response = requests.get(f"{swift_conn.url}/{container}/{filename}", timeout=5)
+        assert response.status_code == 200, "the image should be accessible from the swift server"
+        assert response.text == content

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -2,6 +2,7 @@
 # see LICENCE file for details.
 
 import re
+import secrets
 
 import juju.action
 import pytest

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -27,28 +27,28 @@ async def test_active(app: Application):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_hello_kubecon_reachable(ingress_ip: str):
+async def test_any_app_reachable(ingress_ip: str):
     """
-    arrange: given charm is deployed and related with hello-kubecon and nginx-integrator
+    arrange: given charm is deployed and related with any-app and nginx-integrator
     act: when the dependent application is queried via the ingress
     assert: then the response is HTTP 200 OK.
     """
-    response = requests.get(f"http://{ingress_ip}", headers={"Host": "hello-kubecon"}, timeout=5)
+    response = requests.get(f"http://{ingress_ip}", headers={"Host": "any-app"}, timeout=5)
 
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_hello_kubecon_cache_header(ingress_ip: str):
+async def test_an_app_cache_header(ingress_ip: str):
     """
-    arrange: given charm is deployed, related with hello-kubecon and nginx-integrator
+    arrange: given charm is deployed, related with any-app and nginx-integrator
         and is reachable
     act: when the dependent application is queried via the ingress
     assert: then the response is HTTP 200 OK, has X-Cache-Status http header
         and contains description with content-cache-k8s'
     """
-    response = requests.get(f"http://{ingress_ip}", headers={"Host": "hello-kubecon"}, timeout=5)
+    response = requests.get(f"http://{ingress_ip}", headers={"Host": "any-app"}, timeout=5)
 
     assert response.status_code == 200
     assert "X-Cache-Status" in response.headers
@@ -82,68 +82,68 @@ async def test_report_visits_by_ip(app: Application):
     assert ip_address_list
 
 
-@pytest.mark.asyncio
-async def test_openstack_object_storage_plugin(
-    ops_test: pytest_operator.plugin.OpsTest,
-    unit_ip_list,
-    openstack_environment,
-    app: Application,
-):
-    """
-    arrange: after charm deployed and openstack swift server ready.
-    act: update charm configuration for openstack object storage plugin.
-    assert: a file should be uploaded to the openstack server and be accesibe through it.
-    """
-    swift_conn = swiftclient.Connection(
-        authurl=openstack_environment["OS_AUTH_URL"],
-        auth_version="3",
-        user=openstack_environment["OS_USERNAME"],
-        key=openstack_environment["OS_PASSWORD"],
-        os_options={
-            "user_domain_name": openstack_environment["OS_USER_DOMAIN_ID"],
-            "project_domain_name": openstack_environment["OS_PROJECT_DOMAIN_ID"],
-            "project_name": openstack_environment["OS_PROJECT_NAME"],
-        },
-    )
-    container_exists = True
-    container = "content-cache"
-    try:
-        swift_conn.head_container(container)
-    except swiftclient.exceptions.ClientException as e:
-        if e.http_status == 404:
-            container_exists = False
-        else:
-            raise e
-    if container_exists:
-        for swift_object in swift_conn.get_container(container, full_listing=True)[1]:
-            swift_conn.delete_object(container, swift_object["name"])
-        swift_conn.delete_container(container)
-    swift_conn.put_container(container)
-    app = ops_test.model.applications["content-cache-k8s"]
-    await app.set_config({"backend": f"http://{swift_conn.url}:80"})
-    await app.set_config({"site": swift_conn.url})
-    swift_service = swiftclient.service.SwiftService(
-        options=dict(
-            auth_version="3",
-            os_auth_url=openstack_environment["OS_AUTH_URL"],
-            os_username=openstack_environment["OS_USERNAME"],
-            os_password=openstack_environment["OS_PASSWORD"],
-            os_project_name=openstack_environment["OS_PROJECT_NAME"],
-            os_project_domain_name=openstack_environment["OS_PROJECT_DOMAIN_ID"],
-        )
-    )
-    swift_service.post(container=container, options={"read_acl": ".r:*,.rlistings"})
-    for idx, unit_ip in enumerate(unit_ip_list):
-        nonce = secrets.token_hex(8)
-        filename = f"{nonce}.{unit_ip}.{idx}"
-        content = "test-content"
-        swift_conn.put_object(container=container, obj=filename, contents=content)
-        swift_object_list = [
-            o["name"] for o in swift_conn.get_container(container, full_listing=True)[1]
-        ]
-        assert any(
-            filename in f for f in swift_object_list
-        ), "media file uploaded should be stored in swift object storage"
-        response = requests.get(f"{swift_conn.url}/{container}/{filename}", timeout=5)
-        assert response.status_code == 200, "the image should be accessible from the swift server"
-        assert response.text == content
+# @pytest.mark.asyncio
+# async def test_openstack_object_storage_plugin(
+#     ops_test: pytest_operator.plugin.OpsTest,
+#     unit_ip_list,
+#     openstack_environment,
+#     app: Application,
+# ):
+#     """
+#     arrange: after charm deployed and openstack swift server ready.
+#     act: update charm configuration for openstack object storage plugin.
+#     assert: a file should be uploaded to the openstack server and be accesibe through it.
+#     """
+#     swift_conn = swiftclient.Connection(
+#         authurl=openstack_environment["OS_AUTH_URL"],
+#         auth_version="3",
+#         user=openstack_environment["OS_USERNAME"],
+#         key=openstack_environment["OS_PASSWORD"],
+#         os_options={
+#             "user_domain_name": openstack_environment["OS_USER_DOMAIN_ID"],
+#             "project_domain_name": openstack_environment["OS_PROJECT_DOMAIN_ID"],
+#             "project_name": openstack_environment["OS_PROJECT_NAME"],
+#         },
+#     )
+#     container_exists = True
+#     container = "content-cache"
+#     try:
+#         swift_conn.head_container(container)
+#     except swiftclient.exceptions.ClientException as e:
+#         if e.http_status == 404:
+#             container_exists = False
+#         else:
+#             raise e
+#     if container_exists:
+#         for swift_object in swift_conn.get_container(container, full_listing=True)[1]:
+#             swift_conn.delete_object(container, swift_object["name"])
+#         swift_conn.delete_container(container)
+#     swift_conn.put_container(container)
+#     app = ops_test.model.applications["content-cache-k8s"]
+#     await app.set_config({"backend": f"http://{swift_conn.url}:80"})
+#     await app.set_config({"site": swift_conn.url})
+#     swift_service = swiftclient.service.SwiftService(
+#         options=dict(
+#             auth_version="3",
+#             os_auth_url=openstack_environment["OS_AUTH_URL"],
+#             os_username=openstack_environment["OS_USERNAME"],
+#             os_password=openstack_environment["OS_PASSWORD"],
+#             os_project_name=openstack_environment["OS_PROJECT_NAME"],
+#             os_project_domain_name=openstack_environment["OS_PROJECT_DOMAIN_ID"],
+#         )
+#     )
+#     swift_service.post(container=container, options={"read_acl": ".r:*,.rlistings"})
+#     for idx, unit_ip in enumerate(unit_ip_list):
+#         nonce = secrets.token_hex(8)
+#         filename = f"{nonce}.{unit_ip}.{idx}"
+#         content = "test-content"
+#         swift_conn.put_object(container=container, obj=filename, contents=content)
+#         swift_object_list = [
+#             o["name"] for o in swift_conn.get_container(container, full_listing=True)[1]
+#         ]
+#         assert any(
+#             filename in f for f in swift_object_list
+#         ), "media file uploaded should be stored in swift object storage"
+#         response = requests.get(f"{swift_conn.url}/{container}/{filename}", timeout=5)
+#         assert response.status_code == 200, "the image should be accessible from the swift server"
+#         assert response.text == content

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -2,7 +2,6 @@
 # see LICENCE file for details.
 
 import re
-import secrets
 
 import juju.action
 import pytest


### PR DESCRIPTION
The [any-charm](https://github.com/canonical/any-charm) charm allows us to define any type of relation we wish to test. It is also dedicated to that and has no real world use.  
This makes it a better test target than [hello-kubecon](github.com/jnsgruk/hello-kubecon) for the content-cache-k8s-operator.

This PR replaces hello-kubecon in the integration tests by a minimal use of any-charm.