### PR TITLE
Fix ingress lib

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -367,7 +367,7 @@ class ContentCacheCharm(CharmBase):
         """
         config = self.model.config
         relation = self.model.get_relation("ingress-proxy")
-        if relation:
+        if relation.data[relation.app]:
             site = relation.data[relation.app]["service-hostname"]
             svc_name = relation.data[relation.app]["service-name"]
             svc_port = relation.data[relation.app]["service-port"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -367,7 +367,7 @@ class ContentCacheCharm(CharmBase):
         """
         config = self.model.config
         relation = self.model.get_relation("ingress-proxy")
-        if relation.data[relation.app]:
+        if relation:
             site = relation.data[relation.app]["service-hostname"]
             svc_name = relation.data[relation.app]["service-name"]
             svc_port = relation.data[relation.app]["service-port"]


### PR DESCRIPTION
This PR aims to integrate the latest version of the NGINX ingress library and add the custom IngressProxyProvider class the charm had originally as a custom modification to the lib. This fixes the following error in the logs: `ERROR unit.content-cache-k8s/0.juju-log ingress:0: Missing required data fields for ingress relation: service-hostname, service-name, service-port` As we are listening to the relation_joined event instead of the relation_changed now, this may also fix the possible race condition the charm has when executing _make_env_config()