### PR TITLE
add site default configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,8 @@ options:
     type: string
     description: >
       Required if no ingress-proxy relation is established. The site name, e.g. "mysite.local".
+      If the backend is set and this option is empty then the site will default to the application
+      name.
   backend:
     type: string
     description: >

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,7 +39,7 @@ CACHE_PATH = "/var/lib/nginx/proxy/cache"
 CONTAINER_NAME = "content-cache"
 EXPORTER_CONTAINER_NAME = "nginx-prometheus-exporter"
 CONTAINER_PORT = 80
-REQUIRED_JUJU_CONFIGS = ["site", "backend"]
+REQUIRED_JUJU_CONFIGS = ["backend"]
 
 
 class ContentCacheCharm(CharmBase):
@@ -395,7 +395,7 @@ class ContentCacheCharm(CharmBase):
             backend_site_name = config.get("backend_site_name")
             if not backend_site_name:
                 backend_site_name = urlparse(backend).hostname
-            site = config["site"]
+            site = config.get("site") if config.get("site") else self.app.name
 
         cache_all_configs = ""
         if not config["cache_all"]:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -372,10 +372,10 @@ class TestCharm:
         """
         config = self.config
         harness = self.harness
-        config["site"] = None
+        config["backend"] = None
         harness.update_config(config)
         make_pebble_config.assert_not_called()
-        assert harness.charm.unit.status == BlockedStatus("Required config(s) empty: site")
+        assert harness.charm.unit.status == BlockedStatus("Required config(s) empty: backend")
 
     def test_generate_keys_zone(self):
         """
@@ -588,26 +588,9 @@ class TestCharm:
         config = self.config
         harness = self.harness
         harness.disable_hooks()
-        # All missing, should be sorted.
         config.pop("backend")
-        config.pop("site")
         harness.update_config(config)
-        expected = ["backend", "site"]
-        assert harness.charm._missing_charm_configs() == expected
-
-    def test_missing_charm_configs_missing_one(self):
-        """
-        arrange: define charm config with missing one
-        act: set charm config
-        assert: ensure required configs present and return those missing
-        """
-        config = self.config
-        harness = self.harness
-        harness.disable_hooks()
-        # One missing.
-        config.pop("site")
-        harness.update_config(config)
-        expected = ["site"]
+        expected = ["backend"]
         assert harness.charm._missing_charm_configs() == expected
 
     def test_missing_charm_configs_unset_all(self):
@@ -619,24 +602,7 @@ class TestCharm:
         config = self.config
         harness = self.harness
         harness.disable_hooks()
-        # All set to None, should be sorted.
         config["backend"] = None
-        config["site"] = None
         harness.update_config(config)
-        expected = ["backend", "site"]
-        assert harness.charm._missing_charm_configs() == expected
-
-    def test_missing_charm_configs_unset_one(self):
-        """
-        arrange: define charm config with one unset
-        act: set charm config
-        assert: ensure required configs present and return those missing
-        """
-        config = self.config
-        harness = self.harness
-        harness.disable_hooks()
-        # One set to None
-        config["site"] = None
-        harness.update_config(config)
-        expected = ["site"]
+        expected = ["backend"]
         assert harness.charm._missing_charm_configs() == expected


### PR DESCRIPTION
Adding site default value (the application name) to the charm. This also means we can remove the checks for site in the required/missing fields.