### PR TITLE
Adapt integration tests to reuse the packed charm

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,5 +25,6 @@ def pytest_addoption(parser: pytest.Parser):
     # export OS_PROJECT_NAME=demo
     # export OS_PASSWORD=nomoresecret
     # export OS_IDENTITY_API_VERSION=3
+    parser.addoption("--charm-file", action="store")
     parser.addoption("--openstack-rc", action="store", default="")
     parser.addoption("--content-cache-image", action="store", default="")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -129,7 +129,7 @@ def charm_file(pytestconfig: Config):
 async def app(
     ops_test: OpsTest,
     app_name: str,
-    charm_name: str,
+    charm_file: str,
     content_cache_image: str,
     nginx_prometheus_exporter_image: str,
     nginx_integrator_app: Application,
@@ -158,7 +158,7 @@ async def app(
     await ops_test.model.wait_for_idle(status="active")
 
     application = await ops_test.model.deploy(
-        charm_name,
+        charm_file,
         application_name=app_name,
         resources={
             "content-cache-image": content_cache_image,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,7 +119,7 @@ async def nginx_integrator_app(ops_test: OpsTest):
 
 
 @fixture(scope="module")
-def charm_file(pytestconfig: pytest.Config):
+def charm_file(pytestconfig: Config):
     """Get the existing charm file."""
     value = pytestconfig.getoption("--charm-file")
     yield f"./{value}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -118,10 +118,18 @@ async def nginx_integrator_app(ops_test: OpsTest):
     yield nginx_integrator_app
 
 
+@fixture(scope="module")
+def charm_file(pytestconfig: pytest.Config):
+    """Get the existing charm file."""
+    value = pytestconfig.getoption("--charm-file")
+    yield f"./{value}"
+
+
 @pytest_asyncio.fixture(scope="module")
 async def app(
     ops_test: OpsTest,
     app_name: str,
+    charm_name: str,
     content_cache_image: str,
     nginx_prometheus_exporter_image: str,
     nginx_integrator_app: Application,
@@ -149,9 +157,8 @@ async def app(
     await run_action(any_app_name, "rpc", method="start_server")
     await ops_test.model.wait_for_idle(status="active")
 
-    app_charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(
-        app_charm,
+        charm_name,
         application_name=app_name,
         resources={
             "content-cache-image": content_cache_image,


### PR DESCRIPTION
Adapt the integration tests to reuse the exisintg charm artifact as per https://github.com/canonical/operator-workflows/pull/162