### PR TITLE
Update charm documentation to mention required external access

### DIFF
--- a/docs/reference/external-access.md
+++ b/docs/reference/external-access.md
@@ -1,0 +1,7 @@
+# External access
+
+The only external access required by this charm is if it's configured to
+connect to an external backend, using the `backend` configuration option. As
+an example, if this is set to `http://mybackend.local:80`, then this charm
+will need to be able to access that hostname on port 80 to be able to serve
+content for it.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Documentation change to mention required external access.

### Rationale

We want to add reference documentation to each charm explaining what external access is required.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
