### PR TITLE
Add Prometheus exporter to ROCK

### DIFF
--- a/content-cache_rock/rockcraft.yaml
+++ b/content-cache_rock/rockcraft.yaml
@@ -15,6 +15,8 @@ parts:
       - nginx-light
       - bash
       - coreutils
+    stage-snaps:
+      - gtrkiller-nginx-prometheus-exporter/latest/edge
   copy-config:
     plugin: dump
     source: .

--- a/content-cache_rock/rockcraft.yaml
+++ b/content-cache_rock/rockcraft.yaml
@@ -16,7 +16,7 @@ parts:
       - bash
       - coreutils
     stage-snaps:
-      - gtrkiller-nginx-prometheus-exporter/latest/edge
+      - rocks-nginx-prometheus-exporter/latest/edge
   copy-config:
     plugin: dump
     source: .

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -35,18 +35,11 @@ source: https://github.com/canonical/content-cache-k8s-operator
 containers:
   content-cache:
     resource: content-cache-image
-  nginx-prometheus-exporter:
-    resource: nginx-prometheus-exporter-image
 
 resources:
   content-cache-image:
     type: oci-image
     description: Docker image for content-cache to run
-  nginx-prometheus-exporter-image:
-    type: oci-image
-    description: Prometheus exporter for nginx
-    auto-fetch: true
-    upstream-source: nginx/nginx-prometheus-exporter:0.11.0
 
 provides:
   metrics-endpoint:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -93,12 +93,6 @@ async def get_unit_ip_list(ops_test: OpsTest, app_name: str):
     yield get_unit_ip_list_action
 
 
-@fixture(scope="module")
-def nginx_prometheus_exporter_image(metadata):
-    """Provide the statsd prometheus exporter image from the metadata."""
-    yield metadata["resources"]["nginx-prometheus-exporter-image"]["upstream-source"]
-
-
 @pytest_asyncio.fixture(scope="function")
 async def unit_ip_list(get_unit_ip_list):
     """Yield ip addresses of current units."""
@@ -131,7 +125,6 @@ async def app(
     app_name: str,
     charm_file: str,
     content_cache_image: str,
-    nginx_prometheus_exporter_image: str,
     nginx_integrator_app: Application,
     run_action,
 ):
@@ -162,7 +155,6 @@ async def app(
         application_name=app_name,
         resources={
             "content-cache-image": content_cache_image,
-            "nginx-prometheus-exporter-image": nginx_prometheus_exporter_image,
         },
         series="jammy",
     )


### PR DESCRIPTION
Applicable spec: [ISD043](https://docs.google.com/document/d/1H9jC6hSAo5eKli5FWLDUKpiP1MjzIfCFeA74vfI2JrM)

### Overview

Add the NGINX Prometheus Exporter as a layer to the content-cache ROCK.

### Rationale

Simplify the charm, reduce container amount, address possible securities issues caused by docker images.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
