### PR TITLE
Fix trivy exit-code

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,6 +1,5 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-exit-code: 0
 timeout: 20m
 scan:
   offline-scan: true


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Stop using exit-code 0 and use .trivyignore instead if required.

### Rationale

Using exit-code 0 makes actions run successfully even is there are vulnerabilities.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
