### PR TITLE
Add redeployment doc

### DIFF
--- a/docs/reference/charm-redeployment.md
+++ b/docs/reference/charm-redeployment.md
@@ -1,5 +1,5 @@
 ## Charm Redeployment
 
-If you need to redeploy the [content-cache-k8s](https://charmhub.io/content-cache-k8s) charm it has no underlying state,
-so going through a normal deployment process using the same configuration options and relations
+If you need to redeploy the [content-cache-k8s](https://charmhub.io/content-cache-k8s) charm, it has no underlying state.
+Hence going through a normal deployment process using the same configuration options and relations
 as your original deployment will suffice.

--- a/docs/reference/charm-redeployment.md
+++ b/docs/reference/charm-redeployment.md
@@ -1,0 +1,5 @@
+## Charm Redeployment
+
+If you need to redeploy the [content-cache-k8s](https://charmhub.io/content-cache-k8s) charm it has no underlying state,
+so going through a normal deployment process using the same configuration options and relations
+as your original deployment will suffice.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -162,7 +162,6 @@ async def app(
 
     apps = [app_name, nginx_integrator_app.name, any_app_name]
     await ops_test.model.add_relation(any_app_name, f"{app_name}:nginx-proxy")
-    await ops_test.model.wait_for_idle(apps=apps)
     await ops_test.model.add_relation(nginx_integrator_app.name, f"{app_name}:nginx-route")
     await ops_test.model.wait_for_idle(apps=apps, wait_for_active=True)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,12 +104,8 @@ async def nginx_integrator_app(ops_test: OpsTest):
     """Deploy nginx-ingress-integrator charm."""
     nginx_integrator_app_name = "nginx-ingress-integrator"
     nginx_integrator_app = await ops_test.model.deploy(nginx_integrator_app_name, trust=True)
-    await ops_test.model.wait_for_idle()
-    assert (
-        ops_test.model.applications[nginx_integrator_app_name].units[0].workload_status
-        == ActiveStatus.name
-    )
-    yield nginx_integrator_app
+    await ops_test.model.wait_for_idle(apps=[nginx_integrator_app.name], wait_for_active=True)
+    return nginx_integrator_app
 
 
 @fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,7 +104,7 @@ async def nginx_integrator_app(ops_test: OpsTest):
     """Deploy nginx-ingress-integrator charm."""
     nginx_integrator_app_name = "nginx-ingress-integrator"
     nginx_integrator_app = await ops_test.model.deploy(nginx_integrator_app_name, trust=True)
-    await ops_test.model.wait_for_idle(apps=[nginx_integrator_app.name], wait_for_active=True)
+    await ops_test.model.wait_for_idle(apps=[nginx_integrator_app.name])
     return nginx_integrator_app
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -162,9 +162,9 @@ async def app(
 
     apps = [app_name, nginx_integrator_app.name, any_app_name]
     await ops_test.model.add_relation(any_app_name, f"{app_name}:nginx-proxy")
-    await ops_test.model.wait_for_idle(apps=apps, status=ActiveStatus.name, timeout=60 * 5)
+    await ops_test.model.wait_for_idle(apps=apps)
     await ops_test.model.add_relation(nginx_integrator_app.name, f"{app_name}:nginx-route")
-    await ops_test.model.wait_for_idle(apps=apps, status=ActiveStatus.name, timeout=60 * 5)
+    await ops_test.model.wait_for_idle(apps=apps, wait_for_active=True)
 
     assert ops_test.model.applications[app_name].units[0].workload_status == ActiveStatus.name
     assert ops_test.model.applications[any_app_name].units[0].workload_status == ActiveStatus.name

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -195,9 +195,3 @@ async def ip_address_list(ops_test: OpsTest, app: Application, nginx_integrator_
 async def ingress_ip(ip_address_list: List):
     """First match is the ingress IP."""
     yield ip_address_list[0]
-
-
-@pytest_asyncio.fixture(scope="module")
-async def service_ip(ip_address_list: List):
-    """Last match is the service IP."""
-    yield ip_address_list[-1]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -144,7 +144,7 @@ async def app(
         config={"src-overwrite": json.dumps(any_charm_src_overwrite)},
     )
     await run_action(any_app_name, "rpc", method="start_server")
-    await ops_test.model.wait_for_idle(status="active")
+    await ops_test.model.wait_for_idle()
 
     application = await ops_test.model.deploy(
         charm_file,

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,7 +1,5 @@
 requests
-pytest-operator
 python-keystoneclient
 python-swiftclient
 Pillow
-pytest
-pytest-cov
+

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -5,6 +5,7 @@
 
 import re
 import secrets
+from typing import List
 
 import juju.action
 import pytest
@@ -59,15 +60,19 @@ async def test_an_app_cache_header(ingress_ip: str):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_service_reachable(service_ip: str):
+async def test_unit_reachable(unit_ip_list: List):
     """
     arrange: given charm has been built, deployed and related to a dependent application
-    act: when the dependent application is queried via the service
+    act: when the dependent application is queried via the unit
     assert: then the response is HTTP 200 OK.
     """
-    response = requests.get(f"http://{service_ip}:8080", timeout=5)
+    # Check we are querying at least one unit.
+    assert len(unit_ip_list) > 0
 
-    assert response.status_code == 200
+    for unit_ip in unit_ip_list:
+        response = requests.get(f"http://{unit_ip}:8080", timeout=5)
+
+        assert response.status_code == 200
 
 
 async def test_report_visits_by_ip(app: Application):

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,9 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    pytest==8.1.1
+    pytest-cov
+    pytest-operator
     # Last compatible version with Juju 2.9
     juju==3.0.4
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -105,9 +105,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    # Pin version until the issue with pytest-operator is resolved
-    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
-    pytest==8.1.1
+    pytest
     pytest-cov
     pytest-operator
     # Last compatible version with Juju 2.9

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    # Pin version until the issue with pytest-operator is resolved
+    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
     pytest==8.1.1
     pytest-cov
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add a new document to specify redeployment requirements.

### Rationale

There exists a need to clarify and standardize what to do in a redeployment situation.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
