### PR TITLE
Add optional flags to observability endpoints

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,8 +44,10 @@ resources:
 provides:
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
   nginx-proxy:
     interface: nginx-route
 
@@ -53,6 +55,7 @@ requires:
   logging:
     interface: loki_push_api
     limit: 1
+    optional: true
   nginx-route:
     interface: nginx-route
     limit: 1


### PR DESCRIPTION
### Overview

Mark observability endpoints as optional.

### Rationale

Observability integrations are not required endpoints to deploy the charm and should be marked as optional.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
