### PR TITLE
Use new team name in CODEOWNERS

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,4 +14,3 @@ jobs:
       channel: 1.32-strict/stable
       extra-arguments: "--openstack-rc=${GITHUB_WORKSPACE}/openrc"
       self-hosted-runner: true  
-      self-hosted-runner-label: self-hosted-linux-amd64-jammy-large

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,6 +11,6 @@ jobs:
       setup-devstack-swift: true
       trivy-image-config: "trivy.yaml"
       juju-channel: 3.6/stable
-      channel: 1.32-strict/stable
+      channel: 1.34-strict/stable
       extra-arguments: "--openstack-rc=${GITHUB_WORKSPACE}/openrc"
       self-hosted-runner: true  

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/is-charms
+*       @canonical/platform-engineering


### PR DESCRIPTION
Replace references to is-charms to platform-engineering in CODEOWNERS