### PR TITLE
Updated documentation link

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ description: |
   For DevOps or SRE teams this charm will make operating it simple and straightforward through Juju's clean interface.
 summary: |
   HTTP cache service useful for building CDNs.
-docs: https://content-cache-k8s.readthedocs-hosted.com/
+docs: https://documentation.ubuntu.com/content-cache-k8s-charm/
 maintainers:
   - https://launchpad.net/~content-cache-charmers
 assumes:


### PR DESCRIPTION
### Overview

Update `documentation` key in metadata.yaml

### Rationale

Current value leads to a 404, and I can't set up a redirect in the RTD backend

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation has been added or updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The `CHANGELOG.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
