### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -3,37 +3,40 @@ name: Publish to edge
 on:
   push:
     branches:
-      - main
-      - track/*
+    - main
+    - track/*
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      actions: read
+      contents: write
     secrets: inherit
 
   generate-anycharm-json-artifact:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - run: |
-          python3 - <<'EOF' > /tmp/any_app_backend_src.json
-          import json
-          import pathlib
-          import os
+    - uses: actions/checkout@v6.0.2
+    - run: |
+        python3 - <<'EOF' > /tmp/any_app_backend_src.json
+        import json
+        import pathlib
+        import os
 
-          workspace = os.environ["GITHUB_WORKSPACE"]
-          print(json.dumps(
-            {
-              "any_charm.py": pathlib.Path(f"{workspace}/tests/integration/any_charm.py").read_text(
-                encoding="utf-8"
-              ),
-              "nginx_route.py": pathlib.Path(f"{workspace}/lib/charms/nginx_ingress_integrator/v0/nginx_route.py").read_text(
-                encoding="utf-8"
-              ),
-            }
-          ))
-          EOF
-      - uses: actions/upload-artifact@v7.0.1
-        with:
-          name: any_app_backend_src
-          path: /tmp/any_app_backend_src.json
+        workspace = os.environ["GITHUB_WORKSPACE"]
+        print(json.dumps(
+          {
+            "any_charm.py": pathlib.Path(f"{workspace}/tests/integration/any_charm.py").read_text(
+              encoding="utf-8"
+            ),
+            "nginx_route.py": pathlib.Path(f"{workspace}/lib/charms/nginx_ingress_integrator/v0/nginx_route.py").read_text(
+              encoding="utf-8"
+            ),
+          }
+        ))
+        EOF
+    - uses: actions/upload-artifact@v7.0.1
+      with:
+        name: any_app_backend_src
+        path: /tmp/any_app_backend_src.json


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.